### PR TITLE
Reflect Queue Updates In Database 🧶

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,23 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
     const serverId = oldChannel.member.guild.id;
     const {id, username} = oldChannel.member.user;
 
-    removePlayerFromQueue(serverId, id);
-    console.log(`user ${username} (${id}) left queue.`);
+    try {
+      removePlayerFromQueue(serverId, id);
+      console.log(`user ${username} (${id}) left queue.`);
+    } catch (err) {
+      console.log(err);
+    }
   } else if (newChannel.channelID === queueID) {
     // User joined the queue channel.
     const serverId = newChannel.member.guild.id;
     const {id, username} = newChannel.member.user;
 
-    offerPlayerToQueue(serverId, id);
-    console.log(`user ${username} (${id}) joined queue.`);
+    try {
+      offerPlayerToQueue(serverId, id);
+      console.log(`user ${username} (${id}) joined queue.`);
+    } catch (err) {
+      console.log(err);
+    }
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+const { offerPlayerToQueue, removePlayerFromQueue } = require('./queries/Queues.js');
 require('dotenv').config();
 
 const BOT_TOKEN = process.env.BOT_TOKEN;

--- a/index.js
+++ b/index.js
@@ -22,15 +22,17 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
   const queueID = 807286526408130590;
 
   if (oldChannel.channelID == queueID) {
-    // they left channel
+    // User left the queue channel.
     const serverId = oldChannel.member.guild.id;
     const {id, username} = oldChannel.member.user;
+
     removePlayerFromQueue(serverId, id);
     console.log(`user ${username} (${id}) left queue.`);
   } else if (newChannel.channelID == queueID) {
-    // they joined channel
+    // User joined the queue channel.
     const serverId = newChannel.member.guild.id;
     const {id, username} = newChannel.member.user;
+
     offerPlayerToQueue(serverId, id);
     console.log(`user ${username} (${id}) joined queue.`);
   }

--- a/index.js
+++ b/index.js
@@ -21,14 +21,14 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
    */
   const queueID = 807286526408130590;
 
-  if (oldChannel.channelID == queueID) {
+  if (oldChannel.channelID === queueID) {
     // User left the queue channel.
     const serverId = oldChannel.member.guild.id;
     const {id, username} = oldChannel.member.user;
 
     removePlayerFromQueue(serverId, id);
     console.log(`user ${username} (${id}) left queue.`);
-  } else if (newChannel.channelID == queueID) {
+  } else if (newChannel.channelID === queueID) {
     // User joined the queue channel.
     const serverId = newChannel.member.guild.id;
     const {id, username} = newChannel.member.user;

--- a/index.js
+++ b/index.js
@@ -45,6 +45,6 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
       console.log(err);
     }
   }
-})
+});
 
 client.login(BOT_TOKEN);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
 
   if (oldChannel.channelID == queueID) {
     // they left channel
+    const { serverId } = oldChannel.member.guild.id;
     const {id, username} = oldChannel.member.user;
     console.log(`user ${username} (${id}) left queue.`);
   } else if (newChannel.channelID == queueID) {

--- a/index.js
+++ b/index.js
@@ -23,12 +23,15 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
 
   if (oldChannel.channelID == queueID) {
     // they left channel
-    const { serverId } = oldChannel.member.guild.id;
+    const serverId = oldChannel.member.guild.id;
     const {id, username} = oldChannel.member.user;
+    removePlayerFromQueue(serverId, id);
     console.log(`user ${username} (${id}) left queue.`);
   } else if (newChannel.channelID == queueID) {
     // they joined channel
+    const serverId = newChannel.member.guild.id;
     const {id, username} = newChannel.member.user;
+    offerPlayerToQueue(serverId, id);
     console.log(`user ${username} (${id}) joined queue.`);
   }
 })


### PR DESCRIPTION
Safely call the methods responsible for updating the queue in the database when people join and leave their local server queue.

<code>removePlayerFromQueue</code> removes a player from the queue. Used when the user leaves their local server queue.
<code>offerPlayerToQueue</code> adds a player to the queue. Used when the user joins their local server queue.

A future PR will need to dynamically change the target queue, since it is currently hard-coded.