### PR TITLE
Implement FIFO Queue Methods 🗂️

### DIFF
--- a/database/utils/dispose.js
+++ b/database/utils/dispose.js
@@ -1,3 +1,9 @@
+/**
+ * Safely deletes a Firebase database Reference after use.
+ * Useful for deleting data when it is no longer needed.
+ * @param {*} Reference a firebase reference.
+ * @throws if there is an error removing the Reference.
+ */
 const dispose = async (Reference) => {
   try {
     await Reference.remove();

--- a/database/utils/dispose.js
+++ b/database/utils/dispose.js
@@ -1,0 +1,12 @@
+const dispose = async (Reference) => {
+  try {
+    await Reference.remove();
+  } catch (err) {
+    console.log(err);
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = dispose;

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -12,13 +12,14 @@ const pollPlayer = (serverId) => {
  * @param {*} numberOfPlayers 
  * @throws if there aren't that many players in the queue,
  */
-const pollPlayers = (serverId, numberOfPlayers) => {
-  QueueTable.child(serverId)
+const pollPlayers = async (serverId, numberOfPlayers) => {
+  const res = await QueueTable.child(serverId)
     .limitToFirst(numberOfPlayers)
     .get()
     .then(res => res.val())
-    .then(data => console.log(data))
     .catch(err => console.log(err));
+
+  return res;
 }
 
 /**

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -1,35 +1,39 @@
+const dispose = require('../database/utils/dispose.js');
 const { QueueTable } = require('../database/firebase.js');
 
 /**
  * Gets latest Player from queue.
  */
-const pollPlayer = (serverId) => {
-  pollPlayers(serverId, 1);
-}
+const pollPlayer = async (serverId) => pollPlayers(serverId, 1);
 
 /**
  * Get latest numberOfPlayers players from queue.
  * @param {*} numberOfPlayers 
  * @throws if there aren't that many players in the queue,
  */
-const pollPlayers = async (serverId, numberOfPlayers) => {
-  const res = await QueueTable.child(serverId)
+const pollPlayers = async (serverId, numberOfPlayers) =>
+  QueueTable.child(serverId)
     .limitToFirst(numberOfPlayers)
     .get()
-    .then(res => res.val())
-    .catch(err => console.log(err));
+    .then(querySnapshot => {
+      const data = querySnapshot.val();
+      Object.keys(data).forEach(user => dispose(querySnapshot.ref.child(user)));
 
-  return res;
-}
+      return data;
+    })
+    .catch(err => console.log(err));
 
 /**
  * Adds the given user to the queue.
  * @param {*} user 
  * @throws if the player is already in the queue or the operation otherwise fails.
  */
-const offerPlayerToQueue = (serverId, user) => {
-
-}
+const offerPlayerToQueue = async (serverId, user) =>
+  QueueTable
+    .child(serverId)
+    .child(user)
+    .set(true)
+    .catch(err => console.log(err));
 
 /**
  * Removes a specific user out of the queue, based on the userid.

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -31,7 +31,7 @@ const pollPlayers = async (serverId, numberOfPlayers) =>
 const offerPlayerToQueue = async (serverId, user) =>
   QueueTable
     .child(serverId)
-    .child(user)
+    .child(+ new Date())
     .set(true)
     .catch(err => console.log(err));
 

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -13,6 +13,7 @@ const pollPlayer = async (serverId) => pollPlayers(serverId, 1);
  */
 const pollPlayers = async (serverId, numberOfPlayers) =>
   QueueTable.child(serverId)
+    .orderByValue()
     .limitToFirst(numberOfPlayers)
     .get()
     .then(querySnapshot => {

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -32,8 +32,8 @@ const pollPlayers = async (serverId, numberOfPlayers) =>
 const offerPlayerToQueue = async (serverId, user) =>
   QueueTable
     .child(serverId)
-    .child(+ new Date())
-    .set(true)
+    .child(user)
+    .set(+ new Date())
     .catch(err => console.log(err));
 
 /**
@@ -49,3 +49,8 @@ const removePlayerFromQueue = async (serverId, user) => await dispose(QueueTable
 const getQueueSize = (serverId) => {
 
 }
+
+offerPlayerToQueue(1, 'kim')
+offerPlayerToQueue(1, 'alice')
+offerPlayerToQueue(1, 'katie')
+offerPlayerToQueue(1, 'fred')

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -41,7 +41,7 @@ const offerPlayerToQueue = async (serverId, user) =>
  * @param {*} serverId 
  * @param {*} user 
  */
-const removePlayerFromQueue = async (serverId, user) => await dispose(QueueTable.child(serverId).child(user));
+const removePlayerFromQueue = (serverId, user) => dispose(QueueTable.child(serverId).child(user));
 
 /**
  * Returns the number of players in the queue

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -30,8 +30,7 @@ const pollPlayers = async (serverId, numberOfPlayers) =>
  * @throws if the player is already in the queue or the operation otherwise fails.
  */
 const offerPlayerToQueue = async (serverId, user) =>
-  QueueTable
-    .child(serverId)
+  QueueTable.child(serverId)
     .child(user)
     .set(+ new Date())
     .catch(err => console.log(err));

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -48,3 +48,10 @@ const removePlayerFromQueue = (serverId, user) => dispose(QueueTable.child(serve
 const getQueueSize = (serverId) => {
 
 }
+
+module.exports = {
+  pollPlayer,
+  pollPlayers,
+  offerPlayerToQueue,
+  removePlayerFromQueue
+}

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -40,9 +40,7 @@ const offerPlayerToQueue = async (serverId, user) =>
  * @param {*} serverId 
  * @param {*} user 
  */
-const removePlayerFromQueue = (serverId, user) => {
-
-}
+const removePlayerFromQueue = (serverId, user) => await dispose(QueueTable.child(serverId).child(user));
 
 /**
  * Returns the number of players in the queue

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -14,7 +14,7 @@ const pollPlayer = async (serverId) => pollPlayers(serverId, 1);
 const pollPlayers = async (serverId, numberOfPlayers) =>
   QueueTable.child(serverId)
     .orderByValue()
-    .limitToFirst(numberOfPlayers)
+    .limitToLast(numberOfPlayers)
     .get()
     .then(querySnapshot => {
       const data = querySnapshot.val();
@@ -49,8 +49,3 @@ const removePlayerFromQueue = async (serverId, user) => await dispose(QueueTable
 const getQueueSize = (serverId) => {
 
 }
-
-offerPlayerToQueue(1, 'kim')
-offerPlayerToQueue(1, 'alice')
-offerPlayerToQueue(1, 'katie')
-offerPlayerToQueue(1, 'fred')

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -40,7 +40,7 @@ const offerPlayerToQueue = async (serverId, user) =>
  * @param {*} serverId 
  * @param {*} user 
  */
-const removePlayerFromQueue = (serverId, user) => await dispose(QueueTable.child(serverId).child(user));
+const removePlayerFromQueue = async (serverId, user) => await dispose(QueueTable.child(serverId).child(user));
 
 /**
  * Returns the number of players in the queue

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -13,8 +13,8 @@ const pollPlayer = async (serverId) => pollPlayers(serverId, 1);
  */
 const pollPlayers = async (serverId, numberOfPlayers) =>
   QueueTable.child(serverId)
-    .orderByValue()
-    .limitToLast(numberOfPlayers)
+    .orderByValue() // Orders with NEWEST first
+    .limitToLast(numberOfPlayers) // Grab the OLDEST numberOfPlayers children
     .get()
     .then(querySnapshot => {
       const data = querySnapshot.val();

--- a/queries/Queue.js
+++ b/queries/Queue.js
@@ -1,8 +1,10 @@
+const { QueueTable } = require('../database/firebase.js');
+
 /**
  * Gets latest Player from queue.
  */
 const pollPlayer = (serverId) => {
-
+  pollPlayers(serverId, 1);
 }
 
 /**
@@ -11,7 +13,12 @@ const pollPlayer = (serverId) => {
  * @throws if there aren't that many players in the queue,
  */
 const pollPlayers = (serverId, numberOfPlayers) => {
-  
+  QueueTable.child(serverId)
+    .limitToFirst(numberOfPlayers)
+    .get()
+    .then(res => res.val())
+    .then(data => console.log(data))
+    .catch(err => console.log(err));
 }
 
 /**
@@ -20,7 +27,7 @@ const pollPlayers = (serverId, numberOfPlayers) => {
  * @throws if the player is already in the queue or the operation otherwise fails.
  */
 const offerPlayerToQueue = (serverId, user) => {
-  
+
 }
 
 /**


### PR DESCRIPTION
Implement the <code>poll</code> and <code>offer</code> methods found in a typical queue.
These methods rely on our firebase database for their functionality.

<code>pollPlayer</code> & <code>pollPlayers</code> take the user from the queue on a first-in-first-out basis.
The FIFO order is maintained by passing in the creation timestamp as the value for the user.
<code>offerPlayerToQueue</code> adds a player to the back of the queue.
<code>removePlayerFromQueue</code> removes a player from the queue <b>out of order</b>. To be used, for example, [when a player leaves/joins a queue](9).

holding off on implementing <code>getQueueSize</code>, since there might be some smart ways to do this (such as updating a stored value). Firebase off the bat does not provide a way to query size without querying the entire database table, and I don't think this is sustainable if we hold a lot of data. It's also kind of slow 🥵

(Note to self, this was accompanied by a firebase security rule to allow ordering by value!)