### PR TITLE
Expose a Reference to SessionTable 🏞️

### DIFF
--- a/database/firebase.js
+++ b/database/firebase.js
@@ -13,4 +13,5 @@ module.exports = {
   ServerTable: database.ref('/servers'),
   QueueTable: database.ref('/queues'),
   ChannelTable: database.ref('/channels'),
+  SessionTable: database.ref('/sessions')
 };


### PR DESCRIPTION
Adds SessionTable to the firebase exports so it can be accessed for queries.