### PR TITLE
Check If Channel is a Queue on User Join/Leave 🧱

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,16 +16,16 @@ client.on('message', msg => {
   }
 });
 
-client.on('voiceStateUpdate', (oldChannel, newChannel) => {
-  if (oldChannel.channel !== null && isQueueChannel(oldChannel.guild.id, oldChannel.channel.id)) {
+client.on('voiceStateUpdate', (oldVoiceState, newVoiceState) => {
+  if (oldVoiceState.channel !== null && isQueueChannel(oldVoiceState.guild.id, oldVoiceState.channel.id)) {
     // they left channel
-    const {id, username} = oldChannel.member.user;
+    const {id, username} = oldVoiceState.member.user;
     console.log(`user ${username} (${id}) left queue.`);
   }
 
-  if (newChannel.channel !== null && isQueueChannel(newChannel.guild.id, newChannel.channel.id)) {
+  if (newVoiceState.channel !== null && isQueueChannel(newVoiceState.guild.id, newVoiceState.channel.id)) {
     // they joined channel
-    const {id, username} = newChannel.member.user;
+    const {id, username} = newVoiceState.member.user;
     console.log(`user ${username} (${id}) joined queue.`);
   }
 })

--- a/index.js
+++ b/index.js
@@ -28,6 +28,6 @@ client.on('voiceStateUpdate', (oldVoiceState, newVoiceState) => {
     const {id, username} = newVoiceState.member.user;
     console.log(`user ${username} (${id}) joined queue.`);
   }
-})
+});
 
 client.login(BOT_TOKEN);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
 require('dotenv').config();
+const { isQueueChannel } = require('./queries/Channel');
 
 const BOT_TOKEN = process.env.BOT_TOKEN;
 
@@ -16,16 +17,11 @@ client.on('message', msg => {
 });
 
 client.on('voiceStateUpdate', (oldChannel, newChannel) => {
-  /**
-   * The ID of the channel being used as the queue.
-   */
-  const queueID = 807286526408130590;
-
-  if (oldChannel.channelID == queueID) {
+  if (oldChannel.channel !== null && isQueueChannel(oldChannel.guild.id, oldChannel.channel.id)) {
     // they left channel
     const {id, username} = oldChannel.member.user;
     console.log(`user ${username} (${id}) left queue.`);
-  } else if (newChannel.channelID == queueID) {
+  } else if (isQueueChannel(newChannel.guild.id, newChannel.channel.id)) {
     // they joined channel
     const {id, username} = newChannel.member.user;
     console.log(`user ${username} (${id}) joined queue.`);

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ client.on('voiceStateUpdate', (oldChannel, newChannel) => {
     // they left channel
     const {id, username} = oldChannel.member.user;
     console.log(`user ${username} (${id}) left queue.`);
-  } else if (isQueueChannel(newChannel.guild.id, newChannel.channel.id)) {
+  }
+
+  if (newChannel.channel !== null && isQueueChannel(newChannel.guild.id, newChannel.channel.id)) {
     // they joined channel
     const {id, username} = newChannel.member.user;
     console.log(`user ${username} (${id}) joined queue.`);


### PR DESCRIPTION
Change the if/else conditions in the voiceStateUpdate hook. We now rely on the <code>isChannelQueue</code> method to determine if the joined queue is a channel.

We also have to check if <code>oldChannel.channel</code> is null since it is possible the user hadn't joined a channel before joining queue channel.

There will be a merge conflict with #9 but they're separate functionalities so it should be fine.