### PR TITLE
Migrate QuestionTable to Firestore ♨️

### DIFF
--- a/database/firebase.js
+++ b/database/firebase.js
@@ -7,9 +7,10 @@ firebase.initializeApp({
 });
 
 const database = firebase.database();
+const firestore = firebase.firestore();
 
 module.exports = {
-  QuestionTable: database.ref('/questions'),
+  QuestionTable: firestore.collection('/questions'),
   ServerTable: database.ref('/servers'),
   QueueTable: database.ref('/queues'),
   ChannelTable: database.ref('/channels'),


### PR DESCRIPTION
Firebase provides two databases: [firestore](https://firebase.google.com/docs/firestore) and [realtime database](https://firebase.google.com/docs/database).

We are moving the <code>QuestionTable</code> to firestore since it has better support for querying and modelling data.

[An article contrasting the two can be found here](https://firebase.google.com/docs/database/rtdb-vs-firestore).