### PR TITLE
Random Question Query 🎛️

### DIFF
--- a/utils/randint.js
+++ b/utils/randint.js
@@ -1,0 +1,12 @@
+/**
+ * Returns random integer between min and max (inclusive).
+ * @param {*} min 
+ * @param {*} max 
+ */
+function randomInt(min, max) {  
+  return Math.floor(
+    Math.random() * (max - min) + min
+  );
+}
+
+module.exports = randomInt;


### PR DESCRIPTION
Create the query that fetches a random question of a particular difficulty.

This relies on changes coming from #29 that integrate an enum used to standardise references to <code>difficulty</code> throughout the code base.

This PR shrinks the question queries all the way down because we can now rely on the enum to ensure valid difficulties are used, meaning no need more <code>getRandomEasyQuestion</code>, <code>getRandomMediumQuestion</code>, <code>getRandomHardQuestion</code>.