### PR TITLE
[🔨]  Handle Invalid Commands, Send Command Response as Message to Client

### DIFF
--- a/commands/errors/InvalidCommandError.js
+++ b/commands/errors/InvalidCommandError.js
@@ -1,0 +1,8 @@
+class InvalidCommandError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'InvalidCommandError';
+  }
+}
+
+module.exports = InvalidCommandError;

--- a/commands/executer.js
+++ b/commands/executer.js
@@ -1,3 +1,4 @@
+const InvalidCommandError = require("./errors/InvalidCommandError");
 const CommandProvider = require("./provider/CommandProvider");
 
 /**
@@ -7,24 +8,19 @@ const CommandProvider = require("./provider/CommandProvider");
  * @returns true if the command was executed correctly
  * @throws if the command could not be executed.
  */
-const executer = (commandObject) => {
+const executer = async (commandObject) => {
   let command;
   try {
     command = CommandProvider.getCommand(commandObject.command);
   } catch (err) {
-    console.log(err);
-    return false;
+    throw new InvalidCommandError(`${commandObject.command} is not a command.`);
   }
 
   try {
-    const effects = command.run(commandObject.args);
-    console.log(`Return output: ${effects}`);
+    return await command.run(commandObject.args);
   } catch (err) {
-    console.log(err);
-    return false;
+    throw err;
   }
-
-  return true;
 }
 
-module.exports = executer;
+module.exports = { executer };

--- a/commands/parser.js
+++ b/commands/parser.js
@@ -21,19 +21,21 @@ const parse = (text) => {
     var args = {};
 
     // Generate arguement pairs from raw arguements.
-    rawArgs.forEach(arg => {
-      var values = /\s\w+/g.exec(arg);
-      if (values) {
-        // Grab all the values as an array.
-        values = arg.match(/\s\w+/g);
+    if (rawArgs) {
+      rawArgs.forEach(arg => {
+        var values = /\s\w+/g.exec(arg);
+        if (values) {
+          // Grab all the values as an array.
+          values = arg.match(/\s\w+/g);
 
-        // Do some post processing on the values to remove lingering spaces
-        for (var i = 0; i < values.length; i++) values[i] = values[i].trim();
-      }
+          // Do some post processing on the values to remove lingering spaces
+          for (var i = 0; i < values.length; i++) values[i] = values[i].trim();
+        }
 
-      const argName = /--\w+[^\s]/g.exec(arg)[0];
-      args[argName] = values;
-    });
+        const argName = /--\w+[^\s]/g.exec(arg)[0];
+        args[argName] = values;
+      });
+    }
 
     return {
       command: command,
@@ -44,4 +46,4 @@ const parse = (text) => {
   }
 }
 
-module.exports = parse;
+module.exports = { parse };

--- a/commands/parser.js
+++ b/commands/parser.js
@@ -38,7 +38,7 @@ const parse = (text) => {
     }
 
     return {
-      command: command,
+      command: command.substr(1),
       args: args
     }
   } else {

--- a/commands/provider/Command.js
+++ b/commands/provider/Command.js
@@ -6,9 +6,9 @@ class Command {
     this.command = Object.freeze(command);
   }
 
-  run = (args) => {
+  run = async (args) => {
     try {
-      this.command(args);
+      return await this.command(args);
     } catch (err) {
       console.error(err);
     }

--- a/commands/provider/CommandProvider.js
+++ b/commands/provider/CommandProvider.js
@@ -9,12 +9,10 @@ commands.helloWorld = new Command((args) => console.log(`Hello World! arguements
 
 // The entry point to access the commands.
 CommandProvider.getCommand = (commandName) => {
-  let command = commandName.substr(1);
-
-  if (commands[command]) {
-    return commands[command];
+  if (commands[commandName]) {
+    return commands[commandName];
   } else {
-    throw new InvalidCommandError(`${command} is not a command.`);
+    throw new InvalidCommandError(`${commandName} is not a command.`);
   }
 }
 

--- a/commands/provider/CommandProvider.js
+++ b/commands/provider/CommandProvider.js
@@ -1,4 +1,5 @@
 const Command = require("./Command");
+const InvalidCommandError = require("../errors/InvalidCommandError");
 
 const CommandProvider = {};
 const commands = {};
@@ -8,10 +9,12 @@ commands.helloWorld = new Command((args) => console.log(`Hello World! arguements
 
 // The entry point to access the commands.
 CommandProvider.getCommand = (commandName) => {
-  if (commands[commandName]) {
-    return commands[commandName];
+  let command = commandName.substr(1);
+
+  if (commands[command]) {
+    return commands[command];
   } else {
-    return new Error(`${commandName} is not a command.`);
+    throw new InvalidCommandError(`${command} is not a command.`);
   }
 }
 

--- a/constants/difficulty.js
+++ b/constants/difficulty.js
@@ -2,7 +2,7 @@
  * Export an object used to represent problem difficulty.
  */
 module.exports = {
-  EASY: 0,
-  MEDIUM: 1,
-  HARD: 2
+  EASY: 'EASY',
+  MEDIUM: 'MEDIUM',
+  HARD: 'HARD'
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ client.on('ready', () => {
   console.log(`Logged in as ${client.user.tag}!`);
 });
 
-client.on('message', msg => {
+client.on('message', async msg => {
   // Ignore messages from bots. Stops recursive loops and miscalls.
   if (msg.author.bot) return;
 
@@ -24,10 +24,12 @@ client.on('message', msg => {
 
   let response;
   try {
-    response = executer(command);
+    response = await executer(command);
     msg.channel.send(response);
   } catch(err) {
-    console.error(err);
+    if (err.name !== 'InvalidCommandError') {
+      msg.channel.send(`We couldn't quite execute your command :(`);
+    }
   }
 });
 


### PR DESCRIPTION
- Introduce a new error for handling invalid commands
- The return statement from a command is treated as output for the user.
- Patch the case where parser recieves a command with no arguements.