### PR TITLE
Use Map<String, Command> instead of Object for storing commands

### DIFF
--- a/commands/provider/CommandProvider.js
+++ b/commands/provider/CommandProvider.js
@@ -3,17 +3,16 @@ const InvalidCommandError = require("../errors/InvalidCommandError");
 const { newQuestion } = require("../exports/newQuestion");
 
 const CommandProvider = {};
-const commands = {};
+const commands = new Map();
 
-// Define each command here.
-commands.helloWorld = new Command((args) => console.log(`Hello World! arguements: ${args.arg1}`));
-
-commands.new = newQuestion;
+// Define new commands here.
+commands.set('new', newQuestion);
 
 // The entry point to access the commands.
 CommandProvider.getCommand = (commandName) => {
-  if (commands[commandName]) {
-    return commands[commandName];
+  let command = commands.get(commandName);
+  if (command) {
+    return command;
   } else {
     throw new InvalidCommandError(`${commandName} is not a command.`);
   }


### PR DESCRIPTION
Using an object leaves vulnerabilities around accessing protected fields such as `__proto__` so we'll change over to using a map.